### PR TITLE
Wiki Monte Carlo follow-up: reproduce runs, page-level extension, report FPR budget miss

### DIFF
--- a/.kb-graph-orphans
+++ b/.kb-graph-orphans
@@ -152,3 +152,4 @@ security/wt-integration-review.md
 swarm_scholar_bench_spec.md
 tutorials/index.md
 whitepaper.md
+research/wiki-monte-carlo-results.md

--- a/docs/research/collusion-fpr-honest-convergence.md
+++ b/docs/research/collusion-fpr-honest-convergence.md
@@ -61,4 +61,4 @@ flags a cluster in every seed in all three fidelity modes and still flags the
 lineage-residual graph; temporal never reaches its 0.7 bar. So the "screen on
 co-location not explained by provenance" rule above holds for pair rules, but a
 community detector needs a null model that includes the board's copy mechanism, not
-just edge removal.
+just edge removal. The content-free detectors this motivates (output correlation, re-derivation infeasibility) and their precision/recall on the pi02 overlap board are written up in [content-free-discriminators.md](content-free-discriminators.md) (bead `vv3j.2`).

--- a/docs/research/wiki-monte-carlo-results.md
+++ b/docs/research/wiki-monte-carlo-results.md
@@ -11,8 +11,32 @@ that historical agents moved between hosts.
   seeds, seeds 10000–10199, output-agreement threshold frozen at 0.8.
 - Moderation confirmation: `runs/wiki_mc_confirm_moderation`, 10 cells × 200
   seeds, the same disjoint seed range.
+- Page-level extension: `runs/wiki_mc_confirm_page_e00` and
+  `runs/wiki_mc_confirm_page_e50`, 6 cells × 200 seeds, seeds 10200–10399,
+  disjoint from both ranges above (added 2026-09-06, see below).
 - Each treatment is paired with a same-seed untreated run. Intervals in the
   runner summaries are seed-level percentile bootstrap intervals.
+
+### Reproduction (2026-09-06)
+
+The three run folders above were not archived when the analysis landed, so
+they were regenerated at commit `f2bbd700` with the frozen invocations:
+
+```
+python scripts/sweep_wiki_mc.py --family all --phase pilot --output runs/wiki_mc_pilot_all
+python scripts/sweep_wiki_mc.py --family detection --phase confirmation --detector-threshold 0.8 --output runs/wiki_mc_confirm_detection
+python scripts/sweep_wiki_mc.py --family moderation --phase confirmation --detector-threshold 0.8 --output runs/wiki_mc_confirm_moderation
+python scripts/analyze_wiki_mc_confirmation.py --input runs/wiki_mc_confirm_moderation --output runs/wiki_mc_confirm_moderation/holm_analysis.json
+```
+
+Every number in the moderation analysis below reproduced exactly (completion
+−0.0511 / −0.0501, writes −49.355, ~11.1 traced displacements per run). The
+per-seed event files total about 2.4 GB across the five folders, so only
+`manifest.json`, `paired_summary.csv`, `summary.{json,csv}` and the Holm
+outputs are archived in `swarm-artifacts`; the full event histories are a
+deterministic function of code revision, configuration and seed. Per-cell
+run-level summaries come from
+`scripts/analyze_wiki_mc_confirmation.py --summary`.
 
 ## Moderation analysis
 
@@ -27,8 +51,36 @@ The strongest effects are the write restrictions: cells `moderation-008` and
 Holm-adjusted p-values below 0.001. Their total-write differences are about
 −49.4 per run. Host deletion cells `moderation-002` and `moderation-003` have
 small completion differences (−0.0037 and −0.0028) but record about 11 traced
-displacements per run. Other deletion/lock contrasts include null completion
-effects after correction.
+displacements per run. Host locks (`moderation-006` and `moderation-007`)
+reduce completion by 0.016 and total writes by about 17.5 per run, both with
+Holm-adjusted p-values below 0.001. Random host deletion (`moderation-004`,
+`moderation-005`) is the only intervention whose completion effect is null
+after correction (Holm p = 1.0); its write reduction (about −1.4 per run) is
+still significant. No cell had a zero-write control run, so percentage
+suppression is defined everywhere.
+
+### Displacement denominators
+
+The protocol requires traced displacement events with their denominator. Over
+the 200 confirmation seeds, in the endogenous-relocation cells:
+
+| Cell | Policy | Works disrupted | Chose to relocate | Traced displacements | Per disrupted | Per relocated |
+|---|---|---|---|---|---|---|
+| moderation-002 | ordered host deletion | 6,312 | 4,524 | 2,225 | 0.353 | 0.492 |
+| moderation-004 | random host deletion | 3,851 | 2,768 | 1,370 | 0.356 | 0.495 |
+| moderation-006 | host lock | 5,754 | 4,005 | 1,933 | 0.336 | 0.483 |
+| moderation-008 | global write lock | 10,675 | 4,840 | 0 | 0.000 | 0.000 |
+
+A "disrupted work" is an in-progress assignment whose host was moderated
+(one `response` event). A traced displacement requires the same agent to later
+publish on a different host. About half of relocation decisions produce a
+traced write; the rest finish independently, miss the deadline, or fail the
+publish draw. Forced relocation raises the relocation count to 100% of
+disrupted works but moves the per-disrupted rate only to 0.36–0.38. Under a
+global write lock agents still "relocate" in the decision rule but nothing is
+writable, so displacement is zero by construction; post-intervention writes
+fall from 49.4 to 0 per run, versus 46.1 (ordered), 47.9 (random) and 31.6
+(lock).
 
 These labels refer to the baseline model's host-level intervention policies.
 `ordered` and `random` choose the host deterministically or randomly. The model
@@ -43,6 +95,109 @@ model; only the permission label differs. Their identical paired outputs are a
 control result: output agreement and timing alone cannot infer authorization.
 The detection runs therefore report screening behavior, not a collusion verdict.
 
-The confirmation bead remains open for a final review of selected contrasts and
-the frozen manifest. The model still excludes poisoning, adversarial policy
+### False-positive budget was not met
+
+The protocol called for observer thresholds fit on pilot data at a declared
+5%-per-run false-positive budget, and for reporting failure rather than
+retuning. The frozen threshold of 0.8 was the runner's pilot default, not a
+fitted value, and it does not meet the budget. Run-level alarm rates on the
+confirmation seeds (Wilson 95% intervals):
+
+| Cell | Regime | Coverage | Mean agreement | Alarm runs / 200 | Rate | Wilson interval |
+|---|---|---|---|---|---|---|
+| detection-000 | independent | 0.25 | 0.794 | 99 | 0.495 | 0.43–0.56 |
+| detection-001 | independent | 1.00 | 0.804 | 109 | 0.545 | 0.48–0.61 |
+| detection-002 | authorized | 0.25 | 0.845 | 143 | 0.715 | 0.65–0.77 |
+| detection-003 | authorized | 1.00 | 0.838 | 145 | 0.725 | 0.66–0.78 |
+| detection-004 | prohibited | 0.25 | 0.845 | 143 | 0.715 | 0.65–0.77 |
+| detection-005 | prohibited | 1.00 | 0.838 | 145 | 0.725 | 0.66–0.78 |
+
+The independent regime, in which no agent ever reads a board, alarms in about
+half of runs. The cause is the model's `independent_accuracy = 0.9`: two
+agents that independently solve the same task agree whenever both are correct,
+so output agreement sits near 0.8 with no sharing at all. Sharing adds only
+about 0.04 of agreement on top of that floor.
+
+Fitting the threshold on the pilot independent cells as the protocol specified
+(95th percentile of run-level agreement) gives 1.000 at 25% coverage and 0.896
+at full coverage. Evaluated on the confirmation seeds, those thresholds yield:
+
+| Coverage | Pilot-fit threshold | Confirmation FPR | Recall on authorized sharing |
+|---|---|---|---|
+| 0.25 | 1.000 | 16 / 200 (8.0%) | 20 / 200 (10%) |
+| 1.00 | 0.896 | 7 / 200 (3.5%) | 40 / 200 (20%) |
+
+At any threshold that respects the budget, the agreement screen recovers at
+most a fifth of runs with 35% shared submissions. This is a post-hoc
+evaluation, reported for transparency, not a replacement of the frozen
+threshold. The screen is uninformative in this model for two separate reasons:
+answer agreement is dominated by correctness rather than copying, and the
+permission label is not observable at all. A useful detector for this model
+would need timing relative to the read event, or lineage, not agreement alone.
+
+## Emergence pilot
+
+Thirty seeds per cell, exploratory. Shared-submission rate is submissions with a
+matching earlier read divided by all assignments.
+
+| Overlap | Deadline | Referrals | Shared rate | Completion | Writes / run |
+|---|---|---|---|---|---|
+| 0.2 | 6 | off | 0.026 | 0.543 | 52.5 |
+| 0.2 | 6 | on | 0.038 | 0.552 | 53.6 |
+| 0.2 | 18 | off | 0.037 | 0.892 | 103.9 |
+| 0.2 | 18 | on | 0.049 | 0.895 | 104.3 |
+| 0.8 | 6 | off | 0.298 | 0.744 | 83.8 |
+| 0.8 | 6 | on | 0.366 | 0.785 | 89.9 |
+| 0.8 | 18 | off | 0.389 | 0.971 | 116.2 |
+| 0.8 | 18 | on | 0.424 | 0.972 | 116.4 |
+
+Task overlap is the dominant lever (roughly tenfold in shared rate). Shorter
+deadlines lower sharing rather than raise it, because a 6-unit deadline leaves
+less time for a peer's answer to appear before the agent's own research ends;
+that is a property of the exponential research-time assumption, not evidence
+about deadline pressure in general. Referrals add 0.01–0.07. No confirmatory
+emergence contrast was selected.
+
+## Page-level moderation extension
+
+`moderation_granularity="page"` was added after the confirmation matrix. Runs
+use the moderation family's first six cells (none / ordered / random × relocation
+mode) with `page_deletion_fraction = 0.5`, budget 3, on seeds 10200–10399, at
+`evasion_learning_probability` 0.0 (`page_e00`) and 0.5 (`page_e50`).
+
+```
+python scripts/sweep_wiki_mc.py --family moderation --phase confirmation --detector-threshold 0.8 --seed-start 10200 --seeds 200 --max-cells 6 --config page_e00.json --output runs/wiki_mc_confirm_page_e00
+# page_e00.json: {"moderation_granularity": "page", "evasion_learning_probability": 0.0}
+```
+
+Contrasts are between treatment runs of different cells on the same seed and
+were not in the prespecified family, so they are exploratory (unadjusted
+sign-flip p-values):
+
+| Contrast (endogenous relocation) | Completion | Total writes | Pages removed / run | Displacements / run |
+|---|---|---|---|---|
+| ordered vs untreated | −0.0034 (p = 0.0002) | −3.09 (p < 0.001) | +16.8 | +10.6 |
+| ordered vs random, evasion 0 | +0.0008 (p = 0.39) | −0.65 (p = 0.003) | +5.97 (p < 0.001) | +2.34 (p < 0.001) |
+| ordered vs random, evasion 0.5 | +0.0006 (p = 0.51) | −0.67 (p = 0.002) | +5.57 (p < 0.001) | +2.34 (p < 0.001) |
+| ordered, evasion 0.5 vs 0 | −0.0002 (p = 0.16) | −0.02 (p = 0.55) | −0.40 (p < 0.001) | +0.005 (p = 1.0) |
+
+Two things to read from this. First, "equal budget" holds in operation count
+but not in pages removed: ordered deletion targets the most populated host each
+sweep and removes about 16.8 pages per run against 10.8 for a uniformly chosen
+host, which is what the plan's warning that equal operation counts need not
+mean equal cost looks like in practice. Second, evasion learning as implemented
+has almost no downstream effect. Authors learn to evade at about 13.5 per run,
+but the per-sweep deletion count is computed from all pages on the host, and
+evaders only shrink the eligible set, so the sweep deletes the same number of
+other pages unless evaders exceed half the host. Total writes, completion and
+displacement are unchanged. To test the historical hypothesis that agents
+learned to dodge alphabetical sweeps, the evasion rule needs teeth: evaders
+should move hosts or rename pages, and the budget should be drawn from the
+eligible set. That is a model change, not a rerun.
+
+The confirmation bead (`gvul`) closed on 2026-09-06 with the run folders
+unarchived; the reproduction above closes that gap. Open items after this pass:
+the detection screen needs a lineage- or timing-aware observer before any
+detection contrast is worth confirming; the evasion rule needs the changes
+described above; and the model still excludes poisoning, adversarial policy
 optimization, search-engine exposure, and realistic natural-language answers.

--- a/scripts/analyze_wiki_mc_confirmation.py
+++ b/scripts/analyze_wiki_mc_confirmation.py
@@ -80,13 +80,13 @@ def summarize(directory: Path) -> list[dict]:
     cells = {cell["id"]: cell for cell in manifest["cells"]}
     rows = []
     for cell_id, cell in cells.items():
-        runs = [json.loads(path.read_text())
-                for path in sorted(directory.glob(f"{cell_id}-seed-*.json"))]
-        if not runs:
-            continue
         metrics: dict[str, list[float]] = defaultdict(list)
         counts = defaultdict(int)
-        for run in runs:
+        n = 0
+        # Stream one payload at a time: each carries a full event log.
+        for path in sorted(directory.glob(f"{cell_id}-seed-*.json")):
+            run = json.loads(path.read_text())
+            n += 1
             for key, value in run["treatment_metrics"].items():
                 metrics[key].append(float(value))
             for key, value in run["control_metrics"].items():
@@ -100,7 +100,8 @@ def summarize(directory: Path) -> list[dict]:
                     counts["displaced"] += 1
                 elif event["type"] == "moderation":
                     counts["evasion_learned"] += event.get("evasion_learned", 0)
-        n = len(runs)
+        if n == 0:
+            continue
         alarms = int(sum(metrics["screen_alarm"]))
         control_alarms = int(sum(metrics["control_screen_alarm"]))
         low, high = wilson(alarms, n)
@@ -136,6 +137,8 @@ def main() -> int:
     args = parser.parse_args()
     if args.summary:
         rows = summarize(args.input)
+        if not rows:
+            raise SystemExit(f"{args.input}: no *-seed-*.json payloads found for any manifest cell")
         args.output.write_text(json.dumps({"input": str(args.input), "cells": rows}, indent=2) + "\n")
         with args.output.with_suffix(".csv").open("w", newline="") as handle:
             writer = csv.DictWriter(handle, fieldnames=list(rows[0]))

--- a/scripts/analyze_wiki_mc_confirmation.py
+++ b/scripts/analyze_wiki_mc_confirmation.py
@@ -11,7 +11,10 @@ import argparse
 import csv
 import hashlib
 import json
+import math
 import random
+import statistics
+from collections import defaultdict
 from pathlib import Path
 
 
@@ -53,11 +56,92 @@ def load_differences(directory: Path, cell_id: str, metric: str) -> list[float]:
     return values
 
 
+def wilson(successes: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    """Wilson score interval for an event proportion across independent runs."""
+    if n == 0:
+        return (0.0, 0.0)
+    p = successes / n
+    denominator = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denominator
+    half = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / denominator
+    return (center - half, center + half)
+
+
+def summarize(directory: Path) -> list[dict]:
+    """Per-cell run-level summary of outcomes the paired CSV does not carry.
+
+    Displacement is reported against two denominators: works disrupted by a
+    moderation action (``response`` events) and works that chose to relocate.
+    Alarm rates are run-level proportions with Wilson intervals; in the
+    detection family the treatment run is the untreated run, so treatment and
+    control are identical and only the treatment side is reported.
+    """
+    manifest = json.loads((directory / "manifest.json").read_text())
+    cells = {cell["id"]: cell for cell in manifest["cells"]}
+    rows = []
+    for cell_id, cell in cells.items():
+        runs = [json.loads(path.read_text())
+                for path in sorted(directory.glob(f"{cell_id}-seed-*.json"))]
+        if not runs:
+            continue
+        metrics: dict[str, list[float]] = defaultdict(list)
+        counts = defaultdict(int)
+        for run in runs:
+            for key, value in run["treatment_metrics"].items():
+                metrics[key].append(float(value))
+            for key, value in run["control_metrics"].items():
+                metrics["control_" + key].append(float(value))
+            events = run["treatment"]["events"]
+            for event in events:
+                if event["type"] == "response":
+                    counts["disrupted"] += 1
+                    counts["relocated"] += event["action"] == "relocate"
+                elif event["type"] == "displacement":
+                    counts["displaced"] += 1
+                elif event["type"] == "moderation":
+                    counts["evasion_learned"] += event.get("evasion_learned", 0)
+        n = len(runs)
+        alarms = int(sum(metrics["screen_alarm"]))
+        control_alarms = int(sum(metrics["control_screen_alarm"]))
+        low, high = wilson(alarms, n)
+        row = {"cell_id": cell_id, "family": cell["family"], "n": n,
+               "overrides": json.dumps(cell["overrides"], sort_keys=True),
+               "coverage": cell["observation_fraction"]}
+        for key in ("completion_rate", "task_success_rate", "shared_submission_rate",
+                    "total_writes", "post_intervention_writes", "displacements",
+                    "removed_pages", "useful_reads", "screen_agreement",
+                    "screen_comparable_pairs"):
+            row[key + "_mean"] = statistics.fmean(metrics[key])
+            row["control_" + key + "_mean"] = statistics.fmean(metrics["control_" + key])
+        row.update(alarm_runs=alarms, alarm_rate=alarms / n, alarm_wilson_low=low,
+                   alarm_wilson_high=high, control_alarm_runs=control_alarms,
+                   zero_write_control_runs=int(sum(v == 0 for v in metrics["control_total_writes"])),
+                   disrupted_works=counts["disrupted"], relocated_works=counts["relocated"],
+                   displaced_works=counts["displaced"], evasion_learned=counts["evasion_learned"],
+                   displaced_per_disrupted=(counts["displaced"] / counts["disrupted"]
+                                            if counts["disrupted"] else None),
+                   displaced_per_relocated=(counts["displaced"] / counts["relocated"]
+                                            if counts["relocated"] else None))
+        rows.append(row)
+    return rows
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--input", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--summary", action="store_true",
+                        help="Write a per-cell run-level summary (any family, any seed "
+                             "count) instead of the 200-seed moderation Holm analysis")
     args = parser.parse_args()
+    if args.summary:
+        rows = summarize(args.input)
+        args.output.write_text(json.dumps({"input": str(args.input), "cells": rows}, indent=2) + "\n")
+        with args.output.with_suffix(".csv").open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+            writer.writeheader()
+            writer.writerows(rows)
+        return 0
     tests = []
     cells = sorted({path.name.split("-seed-")[0]
                     for path in args.input.glob("moderation-*-seed-*.json")})

--- a/tests/test_wiki_sim.py
+++ b/tests/test_wiki_sim.py
@@ -134,3 +134,28 @@ def test_deadlines_produce_one_terminal_event_per_assignment() -> None:
     assert result.metrics["deadline_miss_rate"] > 0
     assert all(event["time"] <= event["deadline"] for event in terminals
                if event["type"] == "submission")
+
+
+def test_confirmation_summary_reports_displacement_denominators(tmp_path) -> None:
+    import json
+    import subprocess
+    import sys
+
+    sweep = subprocess.run(
+        [sys.executable, "scripts/sweep_wiki_mc.py", "--family", "moderation",
+         "--seeds", "2", "--max-cells", "3", "--output", str(tmp_path / "sweep")],
+        capture_output=True, text=True, check=True)
+    assert "pairs" in sweep.stdout
+    subprocess.run(
+        [sys.executable, "scripts/analyze_wiki_mc_confirmation.py", "--summary",
+         "--input", str(tmp_path / "sweep"), "--output", str(tmp_path / "summary.json")],
+        capture_output=True, text=True, check=True)
+    cells = json.loads((tmp_path / "summary.json").read_text())["cells"]
+    assert len(cells) == 3 and all(cell["n"] == 2 for cell in cells)
+    untreated, row = cells[0], cells[2]
+    assert untreated["disrupted_works"] == 0 and untreated["displaced_per_disrupted"] is None
+    assert row["overrides"] == '{"moderation_policy": "ordered", "relocation_mode": "endogenous"}'
+    assert 0 < row["displaced_works"] <= row["relocated_works"] <= row["disrupted_works"]
+    assert row["displaced_per_disrupted"] == row["displaced_works"] / row["disrupted_works"]
+    assert 0 <= row["alarm_wilson_low"] <= row["alarm_rate"] <= row["alarm_wilson_high"] <= 1
+    assert (tmp_path / "summary.csv").exists()


### PR DESCRIPTION
## Summary
- Regenerates the three run folders `docs/research/wiki-monte-carlo-results.md` cited but never archived (pilot, detection and moderation confirmation). Every reported number reproduces exactly.
- Adds a `--summary` mode to `scripts/analyze_wiki_mc_confirmation.py` for run-level outcomes the doc omitted: displacement denominators (~0.35 traced displacements per disrupted work, ~0.49 per relocation), alarm rates with Wilson intervals, emergence pilot sharing rates.
- Reports that the frozen 0.8 agreement threshold never met the plan's 5% per-run false-positive budget: the sharing-free independent regime alarms in ~50% of runs because `independent_accuracy=0.9` makes correct agents agree. At pilot-fit thresholds, recall on 35% shared submissions is 10–20%.
- Runs the page-level ordered-vs-random extension on fresh seeds 10200–10399: equal operation budget removes 16.8 vs 10.8 pages/run; evasion learning as implemented changes which pages are deleted, not how many.
- Corrects the lock-cell sentence (host locks do reduce completion after Holm, −0.016).
- Also carries `fc591e9e` (kb-graph orphan fix) which was on local main but unpushed.

Run summaries are in swarm-artifacts PR (per-seed events are 2.4 GB and regenerate deterministically from the invocations in the doc).

## Test plan
- [x] `python -m pytest tests/test_wiki_sim.py` — 28 passed
- [x] `ruff check swarm/ tests/ scripts/` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHiLxm5kjcLHucL94beyyA